### PR TITLE
FIX: 'web-search.browser.styles' default value is invalid CSS format.

### DIFF
--- a/lib/web-search.coffee
+++ b/lib/web-search.coffee
@@ -31,7 +31,7 @@ module.exports = WebSearch =
           type: "string"
           description: "Additional styles."
           # http://www.dtp-transit.jp/misc/web/post_1881.html
-          default: "*{font-family: font-family: Verdana, \"游ゴシック\", YuGothic, \"ヒラギノ角ゴ ProN W3\", \"Hiragino Kaku Gothic ProN\", \"メイリオ\", Meiryo, sans-serif; !important;}"
+          default: "*{font-family: Verdana, \"游ゴシック\", YuGothic, \"ヒラギノ角ゴ ProN W3\", \"Hiragino Kaku Gothic ProN\", \"メイリオ\", Meiryo, sans-serif !important;}"
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable


### PR DESCRIPTION
'web-search.browser.styles'のデフォルト値としているCSS構文が誤っていたため、そのままでは動作していませんでした。
正しく解釈されるように修正しましたので、よろしければマージをお願いします。
