### PR TITLE
不要なパネルオブジェクトが残り続けている

### DIFF
--- a/lib/web-search-browser-view.coffee
+++ b/lib/web-search-browser-view.coffee
@@ -20,3 +20,6 @@ class WebSearchBrowserView extends View
       @webview[0].goBack()
     @forward.on "click", =>
       @webview[0].goForward()
+
+  destroy: ->
+    @self.browserHide()

--- a/lib/web-search-list-view.coffee
+++ b/lib/web-search-list-view.coffee
@@ -10,8 +10,12 @@ class WebSearchListView extends SelectListView
 
  confirmed: (item) ->
    @self.search(item)
+   @cancel()
    console.log("#{item} was selected")
 
  cancelled: ->
    @self.panelHide()
    console.log("This view was cancelled")
+
+ destroy: ->
+   @cancel()

--- a/lib/web-search.coffee
+++ b/lib/web-search.coffee
@@ -78,9 +78,9 @@ module.exports = WebSearch =
     @webSearchBrowserView.destroy()
 
   panelHide: ->
-    @modalPanel?.hide()
+    @modalPanel?.destroy()
     @modalPanel = null
 
   browserHide: ->
-    @browserPanel?.hide()
+    @browserPanel?.destroy()
     @browserPanel = null


### PR DESCRIPTION
web-searchで検索をすればするほどパネルオブジェクトが生成され続け、前に作成したものは残ったままとなっているようです。
下の添付画像は4回検索を実施した時点でデベロッパーツールで確認したところです。

![モーダルパネルオブジェクト](https://bytebucket.org/from_kyushu/qiita_posts/raw/04e9eea789bdc9b86fd0c52ed0dfcda1d3dfc763/images/web_search_panel_objects_issue/modal_objects.jpg)

![右パネルオブジェクト](https://bytebucket.org/from_kyushu/qiita_posts/raw/04e9eea789bdc9b86fd0c52ed0dfcda1d3dfc763/images/web_search_panel_objects_issue/right_objects.jpg)

コードを確認すると`hide()`メソッドで非表示にしているだけでしたので、オブジェクトを再利用しないのであれば消してよいと判断し`destroy()`メソッドでオブジェクトを消すように修正しました。
また、WebSearchListViewクラスとWebSearchBrowserViewクラスに`destroy()`メソッドが実装されていませんでしたので実装(というほどのものではないですが)しています。

よろしければご検討ください。
